### PR TITLE
Add user registry service

### DIFF
--- a/src/main/java/com/example/websocketdemo/service/UserRegistry.java
+++ b/src/main/java/com/example/websocketdemo/service/UserRegistry.java
@@ -1,0 +1,26 @@
+package com.example.websocketdemo.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class UserRegistry {
+
+    private final Map<String, String> users = new ConcurrentHashMap<>();
+
+    public void addUser(String sessionId, String username) {
+        users.put(sessionId, username);
+    }
+
+    public void removeUser(String sessionId) {
+        users.remove(sessionId);
+    }
+
+    public List<String> getAllUsers() {
+        return new ArrayList<>(users.values());
+    }
+}


### PR DESCRIPTION
## Summary
- add UserRegistry service with ConcurrentHashMap to track websocket session usernames

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b6c1b040832f8d6985a4d5906d0c