### PR TITLE
Add recipient support to ChatMessage

### DIFF
--- a/src/main/java/com/example/websocketdemo/model/ChatMessage.java
+++ b/src/main/java/com/example/websocketdemo/model/ChatMessage.java
@@ -7,11 +7,14 @@ public class ChatMessage {
     private MessageType type;
     private String content;
     private String sender;
+    private String recipient;
 
     public enum MessageType {
         CHAT,
         JOIN,
-        LEAVE
+        LEAVE,
+        USER_LIST,
+        PRIVATE
     }
 
     public MessageType getType() {
@@ -36,5 +39,13 @@ public class ChatMessage {
 
     public void setSender(String sender) {
         this.sender = sender;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
     }
 }


### PR DESCRIPTION
## Summary
- add recipient field to ChatMessage with getters/setters
- extend MessageType enum with USER_LIST and PRIVATE

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a49f986830832fbb50c73902253881