### PR TITLE
Add user registry and private messaging

### DIFF
--- a/src/main/java/com/example/websocketdemo/controller/ChatController.java
+++ b/src/main/java/com/example/websocketdemo/controller/ChatController.java
@@ -1,10 +1,13 @@
 package com.example.websocketdemo.controller;
 
 import com.example.websocketdemo.model.ChatMessage;
+import com.example.websocketdemo.service.ServicesUserRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 /**
@@ -13,10 +16,24 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class ChatController {
 
+    @Autowired
+    private ServicesUserRegistry userRegistry;
+
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+
     @MessageMapping("/chat.sendMessage")
-    @SendTo("/topic/public")
-    public ChatMessage sendMessage(@Payload ChatMessage chatMessage) {
-        return chatMessage;
+    public void sendMessage(@Payload ChatMessage chatMessage) {
+        if (chatMessage.getType() == ChatMessage.MessageType.PRIVATE) {
+            messagingTemplate.convertAndSendToUser(chatMessage.getRecipient(), "/queue/messages", chatMessage);
+        } else {
+            messagingTemplate.convertAndSend("/topic/public", chatMessage);
+        }
+    }
+
+    @MessageMapping("/chat.privateMessage")
+    public void privateMessage(@Payload ChatMessage chatMessage) {
+        messagingTemplate.convertAndSendToUser(chatMessage.getRecipient(), "/queue/messages", chatMessage);
     }
 
     @MessageMapping("/chat.addUser")
@@ -25,6 +42,13 @@ public class ChatController {
                                SimpMessageHeaderAccessor headerAccessor) {
         // Add username in web socket session
         headerAccessor.getSessionAttributes().put("username", chatMessage.getSender());
+        userRegistry.addUser(headerAccessor.getSessionId(), chatMessage.getSender());
+
+        ChatMessage userListMessage = new ChatMessage();
+        userListMessage.setType(ChatMessage.MessageType.USER_LIST);
+        userListMessage.setUserList(userRegistry.getAllUsers());
+        messagingTemplate.convertAndSend("/topic/users", userListMessage);
+
         return chatMessage;
     }
 

--- a/src/main/java/com/example/websocketdemo/model/ChatMessage.java
+++ b/src/main/java/com/example/websocketdemo/model/ChatMessage.java
@@ -1,5 +1,7 @@
 package com.example.websocketdemo.model;
 
+import java.util.List;
+
 /**
  * Created by rajeevkumarsingh on 24/07/17.
  */
@@ -7,11 +9,15 @@ public class ChatMessage {
     private MessageType type;
     private String content;
     private String sender;
+    private String recipient;
+    private List<String> userList;
 
     public enum MessageType {
         CHAT,
         JOIN,
-        LEAVE
+        LEAVE,
+        PRIVATE,
+        USER_LIST
     }
 
     public MessageType getType() {
@@ -36,5 +42,21 @@ public class ChatMessage {
 
     public void setSender(String sender) {
         this.sender = sender;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
+    }
+
+    public List<String> getUserList() {
+        return userList;
+    }
+
+    public void setUserList(List<String> userList) {
+        this.userList = userList;
     }
 }


### PR DESCRIPTION
## Summary
- Inject `ServicesUserRegistry` and `SimpMessagingTemplate` into `ChatController`
- Publish active user list on `/topic/users` when a user joins
- Support private messages via `convertAndSendToUser`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a49fd463b4832fb46477a296f7f39a