### PR TITLE
Remove disconnected users from registry and notify clients

### DIFF
--- a/src/main/java/com/example/websocketdemo/controller/WebSocketEventListener.java
+++ b/src/main/java/com/example/websocketdemo/controller/WebSocketEventListener.java
@@ -1,6 +1,7 @@
 package com.example.websocketdemo.controller;
 
 import com.example.websocketdemo.model.ChatMessage;
+import com.example.websocketdemo.service.ServicesUserRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,9 @@ public class WebSocketEventListener {
     @Autowired
     private SimpMessageSendingOperations messagingTemplate;
 
+    @Autowired
+    private ServicesUserRegistry userRegistry;
+
     @EventListener
     public void handleWebSocketConnectListener(SessionConnectedEvent event) {
         logger.info("Received a new web socket connection");
@@ -34,6 +38,10 @@ public class WebSocketEventListener {
         String username = (String) headerAccessor.getSessionAttributes().get("username");
         if(username != null) {
             logger.info("User Disconnected : " + username);
+
+            // Remove user from registry and notify clients with updated list
+            userRegistry.removeUser(headerAccessor.getSessionId());
+            messagingTemplate.convertAndSend("/topic/users", userRegistry.getAllUsers());
 
             ChatMessage chatMessage = new ChatMessage();
             chatMessage.setType(ChatMessage.MessageType.LEAVE);


### PR DESCRIPTION
## Summary
- inject user registry into websocket listener
- remove disconnected users from registry
- broadcast updated user list to `/topic/users`

## Testing
- ⚠️ `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a49fd56604832fbc78f70e900cbb72