### PR TITLE
Add user destination prefix for WebSocket

### DIFF
--- a/src/main/java/com/example/websocketdemo/config/WebSocketConfig.java
+++ b/src/main/java/com/example/websocketdemo/config/WebSocketConfig.java
@@ -19,6 +19,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.setApplicationDestinationPrefixes("/app");
+        registry.setUserDestinationPrefix("/user");
         registry.enableSimpleBroker("/topic");   // Enables a simple in-memory broker
 
 


### PR DESCRIPTION
## Summary
- allow user-specific messaging via `registry.setUserDestinationPrefix("/user")`

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a49fd618d4832fb45ff4bd76364b3b