### PR TITLE
Add lobby and private messaging UI

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -132,6 +132,39 @@ button.accent {
     margin-top: 10px;
 }
 
+#lobby-page {
+    text-align: center;
+}
+
+.lobby-container {
+    background: #fff;
+    box-shadow: 0 1px 11px rgba(0, 0, 0, 0.27);
+    border-radius: 2px;
+    width: 100%;
+    max-width: 500px;
+    display: inline-block;
+    margin-top: 42px;
+    position: relative;
+    padding: 35px 55px;
+}
+
+#userList {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    text-align: left;
+}
+
+#userList li {
+    padding: 10px 20px;
+    border-bottom: 1px solid #f4f4f4;
+    cursor: pointer;
+}
+
+#userList li:hover {
+    background-color: #f4f4f4;
+}
+
 
 #chat-page {
     position: relative;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -24,6 +24,15 @@
         </div>
     </div>
 
+    <div id="lobby-page" class="hidden">
+        <div class="lobby-container">
+            <h2>Usuarios conectados</h2>
+            <ul id="userList">
+                <li>No hay usuarios conectados</li>
+            </ul>
+        </div>
+    </div>
+
     <div id="chat-page" class="hidden">
         <div class="chat-container">
             <div class="chat-header">


### PR DESCRIPTION
## Summary
- Add lobby page with user list to pick private chats
- Subscribe to user updates and private queues, filter conversations per sender
- Style lobby and user list

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a49fd73c2c832f8b23d995795363d9