### PR TITLE
Add private message listener to chat component

### DIFF
--- a/client/components/Chat.js
+++ b/client/components/Chat.js
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000');
+
+export default function Chat() {
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    const handler = ({ from, message }) => {
+      setMessages((prev) => [...prev, { from, message }]);
+    };
+
+    socket.on('private_message', handler);
+
+    return () => {
+      socket.off('private_message', handler);
+    };
+  }, []);
+
+  return (
+    <div>
+      {messages.map((m, idx) => (
+        <div key={idx}>
+          <strong>{m.from}:</strong> {m.message}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a simple Chat component that listens for `private_message` events from the socket server and updates local message state

## Testing
- `npm test` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68a4b08e22fc832fbe3ed49b94a605a5