### PR TITLE
Implement room-based private chat with join confirmation

### DIFF
--- a/client/components/Chat.js
+++ b/client/components/Chat.js
@@ -7,13 +7,20 @@ export default function Chat() {
   const [messages, setMessages] = useState([]);
 
   useEffect(() => {
+    const joinHandler = ({ roomId }) => {
+      console.log(`Joined room ${roomId}`);
+      socket.emit('joined_room_ack', { roomId });
+    };
+
     const handler = ({ from, message }) => {
       setMessages((prev) => [...prev, { from, message }]);
     };
 
+    socket.on('joined_room', joinHandler);
     socket.on('private_message', handler);
 
     return () => {
+      socket.off('joined_room', joinHandler);
       socket.off('private_message', handler);
     };
   }, []);

--- a/server/src/socket.js
+++ b/server/src/socket.js
@@ -9,6 +9,7 @@ const io = new Server(server, {
 });
 
 const users = new Map();
+const roomAcks = new Map();
 
 io.on('connection', (socket) => {
   console.log('Connected', socket.id);
@@ -18,14 +19,40 @@ io.on('connection', (socket) => {
     console.log(`Registered user ${userId} with socket ${socket.id}`);
   });
 
-  socket.on('private_message', ({ to, message }) => {
+  socket.on('start_private_chat', ({ to, roomId }) => {
     const destSocketId = users.get(to);
-    console.log(`Private message from ${socket.id} to user ${to}`);
+    socket.join(roomId);
+    console.log(`Socket ${socket.id} joined room ${roomId}`);
     if (destSocketId) {
-      io.to(destSocketId).emit('private_message', { from: socket.id, message });
-      console.log(`Forwarded message to socket ${destSocketId}`);
+      const destSocket = io.sockets.sockets.get(destSocketId);
+      if (destSocket) {
+        destSocket.join(roomId);
+        console.log(`Socket ${destSocketId} joined room ${roomId}`);
+        io.to(destSocketId).emit('joined_room', { roomId });
+      }
     } else {
       console.log(`User ${to} not found`);
+    }
+    socket.emit('joined_room', { roomId });
+    roomAcks.set(roomId, new Set());
+  });
+
+  socket.on('joined_room_ack', ({ roomId }) => {
+    const set = roomAcks.get(roomId);
+    if (set) {
+      set.add(socket.id);
+      console.log(`Socket ${socket.id} acknowledged joining room ${roomId}`);
+    }
+  });
+
+  socket.on('private_message', ({ roomId, message }) => {
+    const set = roomAcks.get(roomId);
+    console.log(`Private message from ${socket.id} to room ${roomId}`);
+    if (set && set.size === 2) {
+      io.to(roomId).emit('private_message', { from: socket.id, message });
+      console.log(`Forwarded message to room ${roomId}`);
+    } else {
+      console.log(`Room ${roomId} not ready`);
     }
   });
 


### PR DESCRIPTION
## Summary
- Handle private room creation by joining both users and acknowledging joins
- Deliver private messages to rooms once both users confirm membership
- Notify clients to acknowledge room joins

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a4b3beea14832fbe69104f3f915a0b