### PR TITLE
feat: add lobby page and user list

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -24,6 +24,20 @@
         </div>
     </div>
 
+    <div id="lobby-page" class="hidden">
+        <div class="lobby-container">
+            <h2>Lobby</h2>
+            <div class="users-section">
+                <h3>Users</h3>
+                <ul id="userList"></ul>
+            </div>
+            <div class="chats-section">
+                <h3>Chats</h3>
+                <ul id="chatList"></ul>
+            </div>
+        </div>
+    </div>
+
     <div id="chat-page" class="hidden">
         <div class="chat-container">
             <div class="chat-header">

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -1,12 +1,14 @@
 'use strict';
 
 var usernamePage = document.querySelector('#username-page');
+var lobbyPage = document.querySelector('#lobby-page');
 var chatPage = document.querySelector('#chat-page');
 var usernameForm = document.querySelector('#usernameForm');
 var messageForm = document.querySelector('#messageForm');
 var messageInput = document.querySelector('#message');
 var messageArea = document.querySelector('#messageArea');
 var connectingElement = document.querySelector('.connecting');
+var userListElement = document.querySelector('#userList');
 
 var stompClient = null;
 var username = null;
@@ -21,7 +23,7 @@ function connect(event) {
 
     if(username) {
         usernamePage.classList.add('hidden');
-        chatPage.classList.remove('hidden');
+        lobbyPage.classList.remove('hidden');
 
         var socket = new SockJS('/ws');
         stompClient = Stomp.over(socket);
@@ -35,6 +37,7 @@ function connect(event) {
 function onConnected() {
     // Subscribe to the Public Topic
     stompClient.subscribe('/topic/public', onMessageReceived);
+    stompClient.subscribe('/topic/users', onUsersReceived);
 
     // Tell your username to the server
     stompClient.send("/app/chat.addUser",
@@ -104,6 +107,20 @@ function onMessageReceived(payload) {
 
     messageArea.appendChild(messageElement);
     messageArea.scrollTop = messageArea.scrollHeight;
+}
+
+function onUsersReceived(payload) {
+    var users = JSON.parse(payload.body);
+    userListElement.innerHTML = '';
+    users.forEach(function(user) {
+        var li = document.createElement('li');
+        li.appendChild(document.createTextNode(user));
+        li.addEventListener('click', function() {
+            lobbyPage.classList.add('hidden');
+            chatPage.classList.remove('hidden');
+        });
+        userListElement.appendChild(li);
+    });
 }
 
 


### PR DESCRIPTION
## Summary
- add lobby page with user and chat lists
- subscribe to `/topic/users` and populate lobby
- show lobby after login; open chat when user is selected

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.5)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bcefef74832f92a649ba90ff7523