### PR TITLE
feat: add lobby with realtime user list

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -28,12 +28,8 @@
         <div class="lobby-container">
             <h2>Lobby</h2>
             <div class="users-section">
-                <h3>Users</h3>
+                <h3>Usuarios conectados</h3>
                 <ul id="userList"></ul>
-            </div>
-            <div class="chats-section">
-                <h3>Chats</h3>
-                <ul id="chatList"></ul>
             </div>
         </div>
     </div>

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -23,8 +23,9 @@ function connect(event) {
 
     if(username) {
         usernamePage.classList.add('hidden');
-        // Mostramos el lobby inmediatamente, el contenido se cargará al conectar.
+        // Mostramos el lobby y nos aseguramos de que el chat permanezca oculto.
         lobbyPage.classList.remove('hidden');
+        chatPage.classList.add('hidden');
 
         var socket = new SockJS('/ws');
         stompClient = Stomp.over(socket);
@@ -125,14 +126,17 @@ function onMessageReceived(payload) {
 }
 
 function onUsersReceived(payload) {
-    var users = JSON.parse(payload.body);
-    userListElement.innerHTML = ''; // Limpiamos la lista anterior
+    // Excluimos al usuario actual y actualizamos la lista en tiempo real
+    var users = JSON.parse(payload.body).filter(function(user) {
+        return user !== username;
+    });
 
-    // --- LÓGICA PARA MOSTRAR MENSAJE SI NO HAY USUARIOS ---
+    userListElement.innerHTML = '';
+
     if (users.length === 0) {
         var noUsersLi = document.createElement('li');
         noUsersLi.textContent = 'No hay usuarios conectados.';
-        noUsersLi.style.fontStyle = 'italic'; // Opcional: para darle un estilo diferente
+        noUsersLi.style.fontStyle = 'italic';
         noUsersLi.style.color = '#888';
         userListElement.appendChild(noUsersLi);
     } else {
@@ -140,13 +144,11 @@ function onUsersReceived(payload) {
             var li = document.createElement('li');
             li.appendChild(document.createTextNode(user));
 
-            // Tu lógica para cambiar de vista al hacer clic es correcta.
             li.addEventListener('click', function() {
-                // Aquí podrías añadir lógica para un chat privado si quisieras.
-                // Por ahora, simplemente vamos a la sala de chat pública.
                 lobbyPage.classList.add('hidden');
                 chatPage.classList.remove('hidden');
             });
+
             userListElement.appendChild(li);
         });
     }
@@ -163,5 +165,5 @@ function getAvatarColor(messageSender) {
     return colors[index];
 }
 
-usernameForm.addEventListener('submit', connect, true)
-messageForm.addEventListener('submit', sendMessage, true)
+usernameForm.addEventListener('submit', connect, true);
+messageForm.addEventListener('submit', sendMessage, true);


### PR DESCRIPTION
## Summary
- split lobby and chat sections in the HTML
- subscribe to `/topic/users` and refresh the user list
- keep chat hidden until a user is selected

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c435bef8832f836d9818ac502ae2