### PR TITLE
Add lobby screen and navigation to chat demo

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -296,3 +296,8 @@ button.accent {
         font-size: 1.1em;
     }
 }
+
+#lobby-page ul {
+    list-style-type: none;
+    padding: 0;
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -24,8 +24,20 @@
         </div>
     </div>
 
+    <div id="lobby-page" class="hidden">
+        <div class="chat-container">
+            <button id="backToLogin" type="button" class="default">Volver</button>
+            <h2>Usuarios conectados</h2>
+            <ul id="connectedUsers"></ul>
+            <h2>Chats abiertos</h2>
+            <ul id="openChats"></ul>
+            <button id="forumButton" type="button" class="primary">Entrar al foro</button>
+        </div>
+    </div>
+
     <div id="chat-page" class="hidden">
         <div class="chat-container">
+            <button id="backToLobby" type="button" class="default">Volver</button>
             <div class="chat-header">
                 <h2>Spring WebSocket Chat Demo</h2>
             </div>

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -1,8 +1,12 @@
 'use strict';
 
 var usernamePage = document.querySelector('#username-page');
+var lobbyPage = document.querySelector('#lobby-page');
 var chatPage = document.querySelector('#chat-page');
 var usernameForm = document.querySelector('#usernameForm');
+var forumButton = document.querySelector('#forumButton');
+var backToLoginButton = document.querySelector('#backToLogin');
+var backToLobbyButton = document.querySelector('#backToLobby');
 var messageForm = document.querySelector('#messageForm');
 var messageInput = document.querySelector('#message');
 var messageArea = document.querySelector('#messageArea');
@@ -16,18 +20,42 @@ var colors = [
     '#ffc107', '#ff85af', '#FF9800', '#39bbb0'
 ];
 
-function connect(event) {
+function login(event) {
     username = document.querySelector('#name').value.trim();
 
     if(username) {
         usernamePage.classList.add('hidden');
-        chatPage.classList.remove('hidden');
-
-        var socket = new SockJS('/ws');
-        stompClient = Stomp.over(socket);
-
-        stompClient.connect({}, onConnected, onError);
+        lobbyPage.classList.remove('hidden');
     }
+    event.preventDefault();
+}
+
+function connect(event) {
+    lobbyPage.classList.add('hidden');
+    chatPage.classList.remove('hidden');
+    connectingElement.classList.remove('hidden');
+
+    var socket = new SockJS('/ws');
+    stompClient = Stomp.over(socket);
+
+    stompClient.connect({}, onConnected, onError);
+    event.preventDefault();
+}
+
+function showLogin(event) {
+    lobbyPage.classList.add('hidden');
+    usernamePage.classList.remove('hidden');
+    event.preventDefault();
+}
+
+function showLobby(event) {
+    chatPage.classList.add('hidden');
+    lobbyPage.classList.remove('hidden');
+    if(stompClient !== null) {
+        stompClient.disconnect();
+        stompClient = null;
+    }
+    messageArea.innerHTML = '';
     event.preventDefault();
 }
 
@@ -117,5 +145,8 @@ function getAvatarColor(messageSender) {
     return colors[index];
 }
 
-usernameForm.addEventListener('submit', connect, true)
+usernameForm.addEventListener('submit', login, true)
+forumButton.addEventListener('click', connect, true)
+backToLoginButton.addEventListener('click', showLogin, true)
+backToLobbyButton.addEventListener('click', showLobby, true)
 messageForm.addEventListener('submit', sendMessage, true)


### PR DESCRIPTION
## Summary
- Introduce lobby page after login with placeholders for connected users and open chats
- Add navigation buttons, including back actions, between login, lobby, and forum chat
- Style lobby lists and update JavaScript to handle page transitions and WebSocket connection

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c07171f8832facd12cc62e1410c6