### PR TITLE
Add session user registry and broadcast online users

### DIFF
--- a/src/main/java/com/example/websocketdemo/service/SessionUserRegistry.java
+++ b/src/main/java/com/example/websocketdemo/service/SessionUserRegistry.java
@@ -1,0 +1,27 @@
+package com.example.websocketdemo.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class SessionUserRegistry {
+
+    private final ConcurrentHashMap<String, String> sessionIdToUsername = new ConcurrentHashMap<>();
+
+    public void addUser(String sessionId, String username) {
+        if (sessionId != null && username != null) {
+            sessionIdToUsername.put(sessionId, username);
+        }
+    }
+
+    public String removeUser(String sessionId) {
+        return sessionIdToUsername.remove(sessionId);
+    }
+
+    public Collection<String> getAllUsers() {
+        return sessionIdToUsername.values();
+    }
+}
+


### PR DESCRIPTION
## Summary
- track active WebSocket sessions via `SessionUserRegistry`
- broadcast updated user list on connect/disconnect events
- frontend subscribes to `/topic/users` and lists connected users

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c49ea6d8832fb63c97d7b1beef8b