### PR TITLE
Add in-memory user presence for chat lobby

### DIFF
--- a/src/main/java/com/example/websocketdemo/controller/ChatController.java
+++ b/src/main/java/com/example/websocketdemo/controller/ChatController.java
@@ -2,6 +2,7 @@ package com.example.websocketdemo.controller;
 
 import com.example.websocketdemo.model.ChatMessage;
 import com.example.websocketdemo.service.SessionUserRegistry;
+import com.example.websocketdemo.service.UserPresenceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -19,6 +20,9 @@ public class ChatController {
     @Autowired
     private SessionUserRegistry sessionUserRegistry;
 
+    @Autowired
+    private UserPresenceService userPresenceService;
+
     /**
      * Se ejecuta cuando un cliente se conecta y se registra.
      * Añade al usuario al registro y notifica a todos los clientes la nueva lista de usuarios.
@@ -32,8 +36,11 @@ public class ChatController {
         // Añade el usuario al registro
         sessionUserRegistry.addUser(headerAccessor.getSessionId(), username);
 
+        // Registra al usuario y lo marca como conectado
+        userPresenceService.markOnline(username);
+
         // Envía la lista de usuarios actualizada a todos los suscritos a /topic/users
-        messagingTemplate.convertAndSend("/topic/users", sessionUserRegistry.getAllUsers());
+        messagingTemplate.convertAndSend("/topic/users", userPresenceService.getUsersWithStatus());
     }
 
     /**

--- a/src/main/java/com/example/websocketdemo/controller/WebSocketEventListener.java
+++ b/src/main/java/com/example/websocketdemo/controller/WebSocketEventListener.java
@@ -2,6 +2,7 @@ package com.example.websocketdemo.controller;
 
 import com.example.websocketdemo.model.ChatMessage;
 import com.example.websocketdemo.service.SessionUserRegistry;
+import com.example.websocketdemo.service.UserPresenceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +10,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 
@@ -24,6 +24,9 @@ public class WebSocketEventListener {
     @Autowired
     private SessionUserRegistry sessionUserRegistry;
 
+    @Autowired
+    private UserPresenceService userPresenceService;
+
     @EventListener
     public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
@@ -33,16 +36,23 @@ public class WebSocketEventListener {
         String username = sessionUserRegistry.removeUser(sessionId);
 
         if (username != null) {
-            logger.info("User Disconnected : " + username);
+            boolean stillConnected = sessionUserRegistry.hasActiveSession(username);
 
-            // Creamos un mensaje de LEAVE para el chat público
-            ChatMessage chatMessage = new ChatMessage();
-            chatMessage.setType(ChatMessage.MessageType.LEAVE);
-            chatMessage.setSender(username);
-            messagingTemplate.convertAndSend("/topic/public", chatMessage);
+            if (!stillConnected) {
+                logger.info("User Disconnected : " + username);
+
+                // Creamos un mensaje de LEAVE para el chat público
+                ChatMessage chatMessage = new ChatMessage();
+                chatMessage.setType(ChatMessage.MessageType.LEAVE);
+                chatMessage.setSender(username);
+                messagingTemplate.convertAndSend("/topic/public", chatMessage);
+
+                // Marca al usuario como desconectado solo si no tiene otras sesiones
+                userPresenceService.markOffline(username);
+            }
 
             // Enviamos la lista de usuarios actualizada
-            messagingTemplate.convertAndSend("/topic/users", sessionUserRegistry.getAllUsers());
+            messagingTemplate.convertAndSend("/topic/users", userPresenceService.getUsersWithStatus());
         }
     }
 }

--- a/src/main/java/com/example/websocketdemo/model/UserStatus.java
+++ b/src/main/java/com/example/websocketdemo/model/UserStatus.java
@@ -1,0 +1,30 @@
+package com.example.websocketdemo.model;
+
+public class UserStatus {
+    private String username;
+    private boolean online;
+
+    public UserStatus(String username, boolean online) {
+        this.username = username;
+        this.online = online;
+    }
+
+    public UserStatus() {
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public boolean isOnline() {
+        return online;
+    }
+
+    public void setOnline(boolean online) {
+        this.online = online;
+    }
+}

--- a/src/main/java/com/example/websocketdemo/service/SessionUserRegistry.java
+++ b/src/main/java/com/example/websocketdemo/service/SessionUserRegistry.java
@@ -4,11 +4,12 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 @Service
 public class SessionUserRegistry {
 
-    private final ConcurrentHashMap<String, String> sessionIdToUsername = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> sessionIdToUsername = new ConcurrentHashMap<>();
 
     public void addUser(String sessionId, String username) {
         if (sessionId != null && username != null) {
@@ -18,6 +19,10 @@ public class SessionUserRegistry {
 
     public String removeUser(String sessionId) {
         return sessionIdToUsername.remove(sessionId);
+    }
+
+    public boolean hasActiveSession(String username) {
+        return username != null && sessionIdToUsername.containsValue(username);
     }
 
     public Collection<String> getAllUsers() {

--- a/src/main/java/com/example/websocketdemo/service/UserPresenceService.java
+++ b/src/main/java/com/example/websocketdemo/service/UserPresenceService.java
@@ -1,0 +1,35 @@
+package com.example.websocketdemo.service;
+
+import com.example.websocketdemo.model.UserStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Service
+public class UserPresenceService {
+
+    private final ConcurrentHashMap<String, Boolean> usersStatus = new ConcurrentHashMap<>();
+
+    public void markOnline(String username) {
+        if (username == null) {
+            return;
+        }
+        usersStatus.put(username, true);
+    }
+
+    public void markOffline(String username) {
+        if (username == null) {
+            return;
+        }
+        usersStatus.put(username, false);
+    }
+
+    public Collection<UserStatus> getUsersWithStatus() {
+        return usersStatus.entrySet()
+                .stream()
+                .map(entry -> new UserStatus(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -300,4 +300,44 @@ button.accent {
 #lobby-page ul {
     list-style-type: none;
     padding: 0;
+    margin: 0;
+}
+
+#lobby-page #connectedUsers .user-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 4px;
+    border-bottom: 1px solid #f1f1f1;
+}
+
+#lobby-page #connectedUsers .user-status {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: inline-block;
+    background: #c1c1c1;
+}
+
+#lobby-page #connectedUsers .user-status.online {
+    background: #2ecc71;
+    box-shadow: 0 0 0 4px rgba(46, 204, 113, 0.15);
+}
+
+#lobby-page #connectedUsers .user-status.offline {
+    background: #c1c1c1;
+}
+
+#lobby-page #connectedUsers .user-name {
+    flex: 1;
+    font-weight: 600;
+}
+
+#lobby-page #connectedUsers .user-state-label {
+    font-size: 12px;
+    color: #777;
+}
+
+#lobby-page #connectedUsers .user-state-label.online {
+    color: #2c9c5d;
 }

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -122,16 +122,42 @@ function onUsersReceived(payload) {
     var users = JSON.parse(payload.body);
     connectedUsers.innerHTML = ''; // Limpia el mensaje "Conectando..." o la lista anterior
 
-    if (users.length === 0) {
+    if (!users || users.length === 0) {
         var li = document.createElement('li');
         li.textContent = 'No hay usuarios conectados';
         connectedUsers.appendChild(li);
     } else {
-        users.forEach(function(user) {
-            var li = document.createElement('li');
-            li.textContent = user;
-            connectedUsers.appendChild(li);
-        });
+        users
+            .slice()
+            .sort(function(a, b) {
+                if (a.online === b.online) {
+                    return a.username.localeCompare(b.username);
+                }
+                return a.online ? -1 : 1;
+            })
+            .forEach(function(user) {
+                var li = document.createElement('li');
+                li.classList.add('user-row');
+
+                var statusIndicator = document.createElement('span');
+                statusIndicator.classList.add('user-status');
+                statusIndicator.classList.add(user.online ? 'online' : 'offline');
+                statusIndicator.title = user.online ? 'En línea' : 'Desconectado';
+
+                var nameElement = document.createElement('span');
+                nameElement.classList.add('user-name');
+                nameElement.textContent = user.username;
+
+                var stateLabel = document.createElement('span');
+                stateLabel.classList.add('user-state-label');
+                stateLabel.classList.add(user.online ? 'online' : 'offline');
+                stateLabel.textContent = user.online ? 'En línea' : 'Desconectado';
+
+                li.appendChild(statusIndicator);
+                li.appendChild(nameElement);
+                li.appendChild(stateLabel);
+                connectedUsers.appendChild(li);
+            });
     }
 }
 


### PR DESCRIPTION
## Summary
- add an in-memory presence service to register users and track online/offline state
- update websocket handlers to broadcast user status updates when joining or disconnecting
- refresh the lobby UI to display each user with an online/offline indicator

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d5fdb0e4832f8a748fa3a2a519d5)