### PR TITLE
Add in-memory private chat history

### DIFF
--- a/src/main/java/com/example/websocketdemo/controller/ChatController.java
+++ b/src/main/java/com/example/websocketdemo/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.example.websocketdemo.controller;
 
 import com.example.websocketdemo.model.ChatMessage;
+import com.example.websocketdemo.service.ConversationHistoryService;
 import com.example.websocketdemo.service.SessionUserRegistry;
 import com.example.websocketdemo.service.UserPresenceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,9 @@ public class ChatController {
 
     @Autowired
     private UserPresenceService userPresenceService;
+
+    @Autowired
+    private ConversationHistoryService conversationHistoryService;
 
     /**
      * Se ejecuta cuando un cliente se conecta y se registra.
@@ -74,6 +78,7 @@ public class ChatController {
         messagingTemplate.convertAndSend("/topic/private." + conversationId, chatMessage);
         messagingTemplate.convertAndSend("/topic/private.inbox." + chatMessage.getTarget(), chatMessage);
         messagingTemplate.convertAndSend("/topic/private.inbox." + chatMessage.getSender(), chatMessage);
+        conversationHistoryService.append(chatMessage);
     }
 
     private String buildConversationId(String sender, String target) {

--- a/src/main/java/com/example/websocketdemo/controller/WebSocketEventListener.java
+++ b/src/main/java/com/example/websocketdemo/controller/WebSocketEventListener.java
@@ -1,6 +1,7 @@
 package com.example.websocketdemo.controller;
 
 import com.example.websocketdemo.model.ChatMessage;
+import com.example.websocketdemo.service.ConversationHistoryService;
 import com.example.websocketdemo.service.SessionUserRegistry;
 import com.example.websocketdemo.service.UserPresenceService;
 import org.slf4j.Logger;
@@ -11,6 +12,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 
 @Component
@@ -26,6 +28,9 @@ public class WebSocketEventListener {
 
     @Autowired
     private UserPresenceService userPresenceService;
+
+    @Autowired
+    private ConversationHistoryService conversationHistoryService;
 
     @EventListener
     public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
@@ -54,5 +59,24 @@ public class WebSocketEventListener {
             // Enviamos la lista de usuarios actualizada
             messagingTemplate.convertAndSend("/topic/users", userPresenceService.getUsersWithStatus());
         }
+    }
+
+    @EventListener
+    public void handleSubscription(SessionSubscribeEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String destination = headerAccessor.getDestination();
+        if (destination == null || !destination.startsWith("/topic/private.")) {
+            return;
+        }
+
+        String conversationId = destination.substring("/topic/private.".length());
+        String username = (String) headerAccessor.getSessionAttributes().get("username");
+
+        if (conversationId == null || username == null) {
+            return;
+        }
+
+        conversationHistoryService.getHistory(conversationId)
+                .forEach(message -> messagingTemplate.convertAndSend("/topic/private.inbox." + username, message));
     }
 }

--- a/src/main/java/com/example/websocketdemo/service/ConversationHistoryService.java
+++ b/src/main/java/com/example/websocketdemo/service/ConversationHistoryService.java
@@ -1,0 +1,67 @@
+package com.example.websocketdemo.service;
+
+import com.example.websocketdemo.model.ChatMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Service
+public class ConversationHistoryService {
+
+    private final Map<String, Deque<ChatMessage>> conversations = new ConcurrentHashMap<>();
+    private final int maxMessagesPerConversation;
+
+    public ConversationHistoryService(@Value("${chat.history.max-messages:50}") int maxMessagesPerConversation) {
+        this.maxMessagesPerConversation = Math.max(1, maxMessagesPerConversation);
+    }
+
+    public void append(ChatMessage message) {
+        if (message == null || message.getConversationId() == null || message.getConversationId().isBlank()) {
+            return;
+        }
+
+        ChatMessage messageCopy = copyMessage(message);
+        Deque<ChatMessage> history = conversations.computeIfAbsent(messageCopy.getConversationId(), key -> new ArrayDeque<>());
+
+        synchronized (history) {
+            if (history.size() >= maxMessagesPerConversation) {
+                history.removeFirst();
+            }
+            history.addLast(messageCopy);
+        }
+    }
+
+    public List<ChatMessage> getHistory(String conversationId) {
+        if (conversationId == null || conversationId.isBlank()) {
+            return List.of();
+        }
+
+        Deque<ChatMessage> history = conversations.get(conversationId);
+        if (history == null) {
+            return List.of();
+        }
+
+        synchronized (history) {
+            return history.stream()
+                    .map(this::copyMessage)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+    }
+
+    private ChatMessage copyMessage(ChatMessage original) {
+        ChatMessage copy = new ChatMessage();
+        copy.setType(original.getType());
+        copy.setContent(original.getContent());
+        copy.setSender(original.getSender());
+        copy.setTarget(original.getTarget());
+        copy.setConversationId(original.getConversationId());
+        return copy;
+    }
+}

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -183,6 +183,13 @@ function startPrivateConversation(targetUser) {
     if (!conversations[conversationId]) {
         conversations[conversationId] = { target: targetUser, messages: [] };
     }
+
+    if (!conversations[conversationId].subscription && stompClient) {
+        conversations[conversationId].subscription = stompClient.subscribe('/topic/private.' + conversationId, function() {
+            // La suscripción se usa para disparar el envío del historial desde el servidor.
+            // Los mensajes en tiempo real siguen llegando por el inbox del usuario.
+        });
+    }
     setActiveConversation(conversationId);
     renderOpenChats();
 }


### PR DESCRIPTION
## Summary
- store bounded in-memory history per normalized private conversation
- replay existing conversation history when a user subscribes to a private topic
- subscribe clients to conversation topics to trigger history retrieval

## Testing
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936e0b673f8832f8f15ae65efcc4c34)