### PR TITLE
Validate private recipients and improve connection feedback

### DIFF
--- a/src/main/java/com/example/websocketdemo/controller/ChatController.java
+++ b/src/main/java/com/example/websocketdemo/controller/ChatController.java
@@ -30,6 +30,8 @@ public class ChatController {
     @Autowired
     private ConversationHistoryService conversationHistoryService;
 
+    private static final String SYSTEM_SENDER = "system";
+
     /**
      * Se ejecuta cuando un cliente se conecta y se registra.
      * Añade al usuario al registro y notifica a todos los clientes la nueva lista de usuarios.
@@ -69,6 +71,20 @@ public class ChatController {
 
     @MessageMapping("/chat.private.{conversationId}")
     public void sendPrivate(@DestinationVariable String conversationId, @Payload ChatMessage chatMessage) {
+        if (chatMessage.getSender() == null || chatMessage.getTarget() == null) {
+            return;
+        }
+
+        if (chatMessage.getSender().equals(chatMessage.getTarget())) {
+            sendError(chatMessage.getSender(), "No puedes enviarte mensajes a ti mismo.");
+            return;
+        }
+
+        if (!userPresenceService.isKnownUser(chatMessage.getTarget())) {
+            sendError(chatMessage.getSender(), "El usuario seleccionado no existe.");
+            return;
+        }
+
         String normalizedId = buildConversationId(chatMessage.getSender(), chatMessage.getTarget());
         if (!normalizedId.isBlank()) {
             conversationId = normalizedId;
@@ -82,6 +98,15 @@ public class ChatController {
         messagingTemplate.convertAndSend("/topic/private.inbox." + chatMessage.getTarget(), chatMessage);
         messagingTemplate.convertAndSend("/topic/private.inbox." + chatMessage.getSender(), chatMessage);
         conversationHistoryService.append(chatMessage);
+    }
+
+    private void sendError(String username, String errorMessage) {
+        ChatMessage error = new ChatMessage();
+        error.setType(ChatMessage.MessageType.PRIVATE_ERROR);
+        error.setSender(SYSTEM_SENDER);
+        error.setTarget(username);
+        error.setContent(errorMessage);
+        messagingTemplate.convertAndSend("/topic/private.inbox." + username, error);
     }
 
     private String buildConversationId(String sender, String target) {

--- a/src/main/java/com/example/websocketdemo/model/ChatMessage.java
+++ b/src/main/java/com/example/websocketdemo/model/ChatMessage.java
@@ -6,7 +6,8 @@ public class ChatMessage {
         CHAT,
         JOIN,
         LEAVE,
-        PRIVATE
+        PRIVATE,
+        PRIVATE_ERROR
     }
 
     private MessageType type;

--- a/src/main/java/com/example/websocketdemo/service/UserPresenceService.java
+++ b/src/main/java/com/example/websocketdemo/service/UserPresenceService.java
@@ -26,6 +26,14 @@ public class UserPresenceService {
         usersStatus.put(username, false);
     }
 
+    public boolean isKnownUser(String username) {
+        return username != null && usersStatus.containsKey(username);
+    }
+
+    public boolean isOnline(String username) {
+        return Boolean.TRUE.equals(usersStatus.get(username));
+    }
+
     public Collection<UserStatus> getUsersWithStatus() {
         return usersStatus.entrySet()
                 .stream()

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -250,6 +250,33 @@ button.accent {
     width: 100%;
 }
 
+.status-banner {
+    max-width: 700px;
+    margin: 12px auto 0 auto;
+    padding: 10px 14px;
+    text-align: center;
+    border-radius: 4px;
+    background: #f1f7ff;
+    color: #0e6fc2;
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+.status-success {
+    color: #2c9c5d !important;
+}
+
+.status-error {
+    color: #ff4743 !important;
+}
+
+.status-warning {
+    color: #c17700 !important;
+}
+
+.status-info {
+    color: #0e6fc2 !important;
+}
+
 
 @media screen and (max-width: 730px) {
 
@@ -441,6 +468,11 @@ button.accent {
     margin-right: 6px;
 }
 
+.private-messages .message-row.system-row {
+    color: #ff4743;
+    font-weight: 600;
+}
+
 .private-empty {
     text-align: center;
     padding: 30px 15px;
@@ -453,6 +485,17 @@ button.accent {
 
 #connectedUsers .user-row:hover {
     background: #f8fbff;
+}
+
+#lobby-page .chat-container {
+    padding: 15px 18px;
+    border-radius: 6px;
+}
+
+#lobby-page h2 {
+    margin-top: 10px;
+    border-bottom: 1px solid #ececec;
+    padding-bottom: 8px;
 }
 
 #privateMessageForm {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -25,6 +25,7 @@
     </div>
 
     <div id="lobby-page" class="hidden">
+        <div id="connectionStatus" class="status-banner hidden">Conectando...</div>
         <div class="lobby-layout">
             <div class="chat-container">
                 <button id="backToLogin" type="button" class="default">Volver</button>

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -11,6 +11,7 @@ var messageForm = document.querySelector('#messageForm');
 var messageInput = document.querySelector('#message');
 var messageArea = document.querySelector('#messageArea');
 var connectingElement = document.querySelector('.connecting');
+var connectionStatusBanner = document.querySelector('#connectionStatus');
 var connectedUsers = document.querySelector('#connectedUsers');
 var openChats = document.querySelector('#openChats');
 var privateChatPanel = document.querySelector('#private-chat-panel');
@@ -25,6 +26,7 @@ var STORAGE_KEY = 'chat-state';
 var stompClient = null;
 var username = null;
 var publicChatSubscription = null;
+var knownUsers = [];
 
 var conversations = {};
 var activeConversationId = null;
@@ -74,6 +76,29 @@ function persistState() {
     }
 }
 
+function showConnectionStatus(message, type) {
+    if (!connectionStatusBanner) {
+        return;
+    }
+
+    connectionStatusBanner.textContent = message;
+    connectionStatusBanner.classList.remove('hidden', 'status-success', 'status-error', 'status-info', 'status-warning');
+    if (type) {
+        connectionStatusBanner.classList.add('status-' + type);
+    }
+}
+
+function setConnectingFeedback(message, type) {
+    if (!connectingElement) {
+        return;
+    }
+    connectingElement.textContent = message;
+    connectingElement.classList.remove('status-success', 'status-error', 'status-info', 'status-warning');
+    if (type) {
+        connectingElement.classList.add('status-' + type);
+    }
+}
+
 function restoreStateAfterLogin() {
     var state = loadSavedState();
     if (!state || state.username !== username) {
@@ -106,6 +131,8 @@ function login(event) {
         usernamePage.classList.add('hidden');
         lobbyPage.classList.remove('hidden');
 
+        showConnectionStatus('Conectando...', 'info');
+
         connectedUsers.innerHTML = '';
         var li = document.createElement('li');
         li.textContent = 'Conectando...';
@@ -122,11 +149,17 @@ function onConnected() {
     stompClient.subscribe('/topic/users', onUsersReceived);
     stompClient.subscribe('/topic/private.inbox.' + username, onPrivateMessageReceived);
 
+    if (stompClient && stompClient.ws) {
+        stompClient.ws.onclose = onSocketClosed;
+    }
+
     stompClient.send("/app/chat.register",
         {},
         JSON.stringify({sender: username, type: 'JOIN'})
     );
 
+    showConnectionStatus('Conectado como ' + username, 'success');
+    setConnectingFeedback('Conectado', 'success');
     restoreStateAfterLogin();
 }
 
@@ -153,6 +186,7 @@ function showLogin(event) {
         stompClient.disconnect();
         stompClient = null;
     }
+    showConnectionStatus('Desconectado', 'warning');
     connectedUsers.innerHTML = '';
     event.preventDefault();
 }
@@ -180,6 +214,7 @@ function resetPrivateChats() {
 
 function onUsersReceived(payload) {
     var users = JSON.parse(payload.body);
+    knownUsers = (users || []).map(function(user) { return user.username; });
     connectedUsers.innerHTML = '';
 
     if (!users || users.length === 0) {
@@ -241,8 +276,13 @@ function onUsersReceived(payload) {
 
 function onError(error) {
     console.error(error);
-    connectingElement.textContent = 'No se pudo conectar al servidor WebSocket. Por favor, refresca la página.';
-    connectingElement.style.color = 'red';
+    setConnectingFeedback('No se pudo conectar al servidor WebSocket. Por favor, refresca la página.', 'error');
+    showConnectionStatus('Error al conectar con el servidor.', 'error');
+}
+
+function onSocketClosed() {
+    setConnectingFeedback('Desconectado del servidor', 'warning');
+    showConnectionStatus('Sesión desconectada. Reintenta conectar.', 'warning');
 }
 
 function sendMessage(event) {
@@ -260,6 +300,9 @@ function sendMessage(event) {
 }
 
 function startPrivateConversation(targetUser) {
+    if (!isValidRecipient(targetUser)) {
+        return;
+    }
     var conversationId = buildConversationId(username, targetUser);
 
     ensureConversation(conversationId, targetUser);
@@ -365,6 +408,18 @@ function renderConversationMessages(conversationId) {
     privateMessageArea.scrollTop = privateMessageArea.scrollHeight;
 }
 
+function renderSystemPrivateMessage(message) {
+    privateMessageArea.innerHTML = '';
+    var row = document.createElement('div');
+    row.classList.add('message-row', 'system-row');
+    var text = document.createElement('span');
+    text.textContent = message.content;
+    row.appendChild(text);
+    privateMessageArea.appendChild(row);
+    setConnectingFeedback(message.content, 'error');
+    showConnectionStatus(message.content, 'error');
+}
+
 function onMessageReceived(payload) {
     var message = JSON.parse(payload.body);
     var messageElement = document.createElement('li');
@@ -404,6 +459,11 @@ function onPrivateMessageReceived(payload) {
     var conversationId = message.conversationId || buildConversationId(message.sender, message.target);
 
     var targetUser = message.sender === username ? message.target : message.sender;
+    if (message.type === 'PRIVATE_ERROR') {
+        renderSystemPrivateMessage(message);
+        return;
+    }
+
     ensureConversation(conversationId, targetUser);
     if (!activeConversationId) {
         activeConversationId = conversationId;
@@ -437,6 +497,10 @@ function sendPrivateMessage(event) {
     }
 
     var conversation = conversations[activeConversationId];
+    if (!isValidRecipient(conversation.target)) {
+        event.preventDefault();
+        return;
+    }
     var chatMessage = {
         sender: username,
         content: messageContent,
@@ -448,6 +512,18 @@ function sendPrivateMessage(event) {
     stompClient.send('/app/chat.private.' + activeConversationId, {}, JSON.stringify(chatMessage));
     privateMessageInput.value = '';
     event.preventDefault();
+}
+
+function isValidRecipient(targetUser) {
+    if (!targetUser || targetUser === username) {
+        showConnectionStatus('Debes seleccionar a otro usuario para conversar.', 'error');
+        return false;
+    }
+    if (knownUsers.indexOf(targetUser) === -1) {
+        showConnectionStatus('El usuario seleccionado no existe o no está disponible.', 'error');
+        return false;
+    }
+    return true;
 }
 
 function getAvatarColor(messageSender) {


### PR DESCRIPTION
## Summary
- prevent selecting invalid private chat recipients both on the client and server, returning clear error feedback
- add connection/disconnection status messaging and style tweaks for lobby panels and private system alerts
- adjust chat styling to reuse existing palette for user lists and status banners

## Testing
- mvn test *(fails: dependency resolution error 502 from repo.maven.apache.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936e5e30f48832fb882f42025911cf7)