### PR TITLE
Add mobile-style layout with tabbed navigation

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -15,21 +15,104 @@ body {
     font-weight: 400;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 1rem;
-    line-height: 1.58;
-    color: #333;
-    background-color: #f4f4f4;
+    line-height: 1.5;
+    color: #1f2933;
+    background-color: #f4f6fb;
     height: 100%;
 }
 
 body:before {
-    height: 50%;
-    width: 100%;
-    position: absolute;
+    display: none;
+}
+
+.app-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background: #f4f6fb;
+    position: relative;
+}
+
+.app-header {
+    position: fixed;
     top: 0;
     left: 0;
-    background: #128ff2;
-    content: "";
-    z-index: 0;
+    right: 0;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 16px;
+    background: #ffffff;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    z-index: 20;
+}
+
+.app-header h1 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.app-main {
+    flex: 1;
+    padding-top: 56px;
+    padding-bottom: 72px;
+    min-height: 0;
+}
+
+.app-section {
+    height: 100%;
+}
+
+.section-scroll {
+    height: 100%;
+    overflow-y: auto;
+    padding: 12px 16px 24px;
+}
+
+.bottom-nav {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 64px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    background: #ffffff;
+    border-top: 1px solid #e5e7eb;
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.04);
+    z-index: 20;
+}
+
+.nav-item {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: #6b7280;
+    gap: 4px;
+    font-weight: 600;
+}
+
+.nav-item .nav-icon {
+    font-size: 18px;
+    line-height: 1;
+}
+
+.nav-item.active {
+    color: #128ff2;
+}
+
+.icon-button {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    color: #128ff2;
+    font-size: 20px;
+    padding: 8px;
 }
 
 .clearfix:after {
@@ -104,6 +187,38 @@ button.accent {
     color: #fff;
 }
 
+.card {
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
+    padding: 12px 14px 16px;
+    margin-bottom: 16px;
+}
+
+.card-header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 8px;
+}
+
+.card-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.chat-card {
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 200px);
+}
+
+.settings-content {
+    color: #4b5563;
+    line-height: 1.6;
+}
+
 #username-page {
     text-align: center;
 }
@@ -133,40 +248,29 @@ button.accent {
 }
 
 
+
 #chat-page {
     position: relative;
     height: 100%;
-}
-
-.chat-container {
-    max-width: 700px;
-    margin-left: auto;
-    margin-right: auto;
-    background-color: #fff;
-    box-shadow: 0 1px 11px rgba(0, 0, 0, 0.27);
-    margin-top: 30px;
-    height: calc(100% - 60px);
-    max-height: 600px;
-    position: relative;
 }
 
 #chat-page ul {
     list-style-type: none;
     background-color: #FFF;
     margin: 0;
-    overflow: auto;
-    overflow-y: scroll;
-    padding: 0 20px 0px 20px;
-    height: calc(100% - 150px);
+    overflow-y: auto;
+    padding: 0 16px 0 16px;
+    flex: 1;
 }
 
 #chat-page #messageForm {
-    padding: 20px;
+    padding: 16px;
+    border-top: 1px solid #ececec;
 }
 
 #chat-page ul li {
     line-height: 1.5rem;
-    padding: 10px 20px;
+    padding: 10px 12px;
     margin: 0;
     border-bottom: 1px solid #f4f4f4;
 }
@@ -242,20 +346,16 @@ button.accent {
 }
 
 .connecting {
-    padding-top: 5px;
+    padding: 10px 16px;
     text-align: center;
     color: #777;
-    position: absolute;
-    top: 65px;
-    width: 100%;
 }
 
 .status-banner {
-    max-width: 700px;
-    margin: 12px auto 0 auto;
+    margin: 12px 0;
     padding: 10px 14px;
     text-align: center;
-    border-radius: 4px;
+    border-radius: 8px;
     background: #f1f7ff;
     color: #0e6fc2;
     box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -24,63 +24,101 @@
         </div>
     </div>
 
-    <div id="lobby-page" class="hidden">
-        <div id="connectionStatus" class="status-banner hidden">Conectando...</div>
-        <div class="lobby-layout">
-            <div class="chat-container">
-                <button id="backToLogin" type="button" class="default">Volver</button>
-                <h2>Usuarios conectados</h2>
-                <ul id="connectedUsers"></ul>
-                <button id="forumButton" type="button" class="primary lobby-button">Entrar al foro</button>
-            </div>
-            <div class="chat-container private-container">
-                <div class="private-panel-header">
-                    <h2>Chats privados</h2>
-                    <p class="private-helper">Selecciona un usuario o un chat abierto para conversar.</p>
-                </div>
-                <ul id="openChats"></ul>
-                <div id="private-chat-panel" class="hidden">
-                    <div class="chat-header">
-                        <h3 id="privateChatHeading">Conversación privada</h3>
-                    </div>
-                    <div id="privateMessageArea" class="private-messages"></div>
-                    <form id="privateMessageForm" name="privateMessageForm">
-                        <div class="form-group">
-                            <div class="input-group clearfix">
-                                <input type="text" id="privateMessage" placeholder="Escribe un mensaje..." autocomplete="off" class="form-control"/>
-                                <button type="submit" class="primary">Enviar</button>
-                            </div>
+    <div id="app-shell" class="hidden">
+        <header class="app-header">
+            <button id="backToLogin" type="button" class="icon-button" aria-label="Volver">
+                &#8592;
+            </button>
+            <h1 id="appTitle">Chat Demo</h1>
+        </header>
+
+        <main class="app-main">
+            <section id="lobby-page" class="app-section hidden">
+                <div class="section-scroll">
+                    <div id="connectionStatus" class="status-banner hidden">Conectando...</div>
+                    <div class="card">
+                        <div class="card-header">
+                            <h2>Usuarios conectados</h2>
                         </div>
-                    </form>
-                </div>
-                <div id="noPrivateChat" class="private-empty">
-                    <p>No hay conversaciones abiertas.</p>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div id="chat-page" class="hidden">
-        <div class="chat-container">
-            <button id="backToLobby" type="button" class="default">Volver</button>
-            <div class="chat-header">
-                <h2>Chat Demo</h2>
-            </div>
-            <div class="connecting">
-                Connecting...
-            </div>
-            <ul id="messageArea">
-
-            </ul>
-            <form id="messageForm" name="messageForm" nameForm="messageForm">
-                <div class="form-group">
-                    <div class="input-group clearfix">
-                        <input type="text" id="message" placeholder="Type a message..." autocomplete="off" class="form-control"/>
-                        <button type="submit" class="primary">Send</button>
+                        <ul id="connectedUsers" class="card-list"></ul>
+                        <button id="forumButton" type="button" class="primary lobby-button">Entrar al foro</button>
+                    </div>
+                    <div class="card">
+                        <div class="card-header">
+                            <h2>Chats privados</h2>
+                            <p class="private-helper">Selecciona un usuario o un chat abierto para conversar.</p>
+                        </div>
+                        <ul id="openChats" class="card-list"></ul>
+                        <div id="private-chat-panel" class="hidden">
+                            <div class="chat-header">
+                                <h3 id="privateChatHeading">Conversación privada</h3>
+                            </div>
+                            <div id="privateMessageArea" class="private-messages"></div>
+                            <form id="privateMessageForm" name="privateMessageForm">
+                                <div class="form-group">
+                                    <div class="input-group clearfix">
+                                        <input type="text" id="privateMessage" placeholder="Escribe un mensaje..." autocomplete="off" class="form-control"/>
+                                        <button type="submit" class="primary">Enviar</button>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                        <div id="noPrivateChat" class="private-empty">
+                            <p>No hay conversaciones abiertas.</p>
+                        </div>
                     </div>
                 </div>
-            </form>
-        </div>
+            </section>
+
+            <section id="chat-page" class="app-section hidden">
+                <div class="section-scroll">
+                    <div class="card chat-card">
+                        <div class="chat-header">
+                            <h2>Chat Demo</h2>
+                        </div>
+                        <div class="connecting">Connecting...</div>
+                        <ul id="messageArea"></ul>
+                        <form id="messageForm" name="messageForm" nameForm="messageForm">
+                            <div class="form-group">
+                                <div class="input-group clearfix">
+                                    <input type="text" id="message" placeholder="Type a message..." autocomplete="off" class="form-control"/>
+                                    <button type="submit" class="primary">Send</button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </section>
+
+            <section id="settings-page" class="app-section hidden">
+                <div class="section-scroll">
+                    <div class="card">
+                        <div class="card-header">
+                            <h2>Ajustes</h2>
+                            <p class="private-helper">Configura tu experiencia dentro de la app móvil.</p>
+                        </div>
+                        <div class="settings-content">
+                            <p>Selecciona una conversación para actualizar tus preferencias o vuelve al lobby para iniciar un chat.</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <nav class="bottom-nav">
+            <button class="nav-item active" data-target="lobby-page" type="button">
+                <span class="nav-icon">&#128101;</span>
+                <span class="nav-label">Usuarios</span>
+            </button>
+            <button class="nav-item" data-target="chat-page" type="button">
+                <span class="nav-icon">&#128172;</span>
+                <span class="nav-label">Chats</span>
+            </button>
+            <button class="nav-item" data-target="settings-page" type="button">
+                <span class="nav-icon">&#9881;</span>
+                <span class="nav-label">Ajustes</span>
+            </button>
+        </nav>
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.1.4/sockjs.min.js"></script>

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -1,12 +1,14 @@
 'use strict';
 
 var usernamePage = document.querySelector('#username-page');
+var appShell = document.querySelector('#app-shell');
+var appTitle = document.querySelector('#appTitle');
 var lobbyPage = document.querySelector('#lobby-page');
 var chatPage = document.querySelector('#chat-page');
+var settingsPage = document.querySelector('#settings-page');
 var usernameForm = document.querySelector('#usernameForm');
 var forumButton = document.querySelector('#forumButton');
 var backToLoginButton = document.querySelector('#backToLogin');
-var backToLobbyButton = document.querySelector('#backToLobby');
 var messageForm = document.querySelector('#messageForm');
 var messageInput = document.querySelector('#message');
 var messageArea = document.querySelector('#messageArea');
@@ -20,6 +22,7 @@ var privateMessageForm = document.querySelector('#privateMessageForm');
 var privateMessageInput = document.querySelector('#privateMessage');
 var privateChatHeading = document.querySelector('#privateChatHeading');
 var noPrivateChat = document.querySelector('#noPrivateChat');
+var navButtons = document.querySelectorAll('.nav-item[data-target]');
 
 var STORAGE_KEY = 'chat-state';
 
@@ -99,6 +102,40 @@ function setConnectingFeedback(message, type) {
     }
 }
 
+function updateTitle(sectionId) {
+    if (!appTitle) {
+        return;
+    }
+    var titles = {
+        'lobby-page': 'Usuarios',
+        'chat-page': 'Chat Demo',
+        'settings-page': 'Ajustes'
+    };
+
+    appTitle.textContent = titles[sectionId] || 'Chat Demo';
+}
+
+function showSection(sectionId) {
+    [lobbyPage, chatPage, settingsPage].forEach(function(section) {
+        if (!section) {
+            return;
+        }
+
+        if (section.id === sectionId) {
+            section.classList.remove('hidden');
+        } else {
+            section.classList.add('hidden');
+        }
+    });
+
+    navButtons.forEach(function(button) {
+        var isActive = button.dataset.target === sectionId;
+        button.classList.toggle('active', isActive);
+    });
+
+    updateTitle(sectionId);
+}
+
 function restoreStateAfterLogin() {
     var state = loadSavedState();
     if (!state || state.username !== username) {
@@ -129,7 +166,11 @@ function login(event) {
 
     if(username) {
         usernamePage.classList.add('hidden');
-        lobbyPage.classList.remove('hidden');
+        if (appShell) {
+            appShell.classList.remove('hidden');
+        }
+
+        showSection('lobby-page');
 
         showConnectionStatus('Conectando...', 'info');
 
@@ -164,8 +205,7 @@ function onConnected() {
 }
 
 function connect(event) {
-    lobbyPage.classList.add('hidden');
-    chatPage.classList.remove('hidden');
+    showSection('chat-page');
 
     publicChatSubscription = stompClient.subscribe('/topic/public', onMessageReceived);
 
@@ -177,8 +217,11 @@ function connect(event) {
 }
 
 function showLogin(event) {
-    lobbyPage.classList.add('hidden');
+    showSection('lobby-page');
     usernamePage.classList.remove('hidden');
+    if (appShell) {
+        appShell.classList.add('hidden');
+    }
 
     resetPrivateChats();
 
@@ -192,8 +235,7 @@ function showLogin(event) {
 }
 
 function showLobby(event) {
-    chatPage.classList.add('hidden');
-    lobbyPage.classList.remove('hidden');
+    showSection('lobby-page');
 
     if (publicChatSubscription) {
         publicChatSubscription.unsubscribe();
@@ -610,6 +652,11 @@ function getUnreadCountForUser(user) {
 usernameForm.addEventListener('submit', login, true);
 forumButton.addEventListener('click', connect, true);
 backToLoginButton.addEventListener('click', showLogin, true);
-backToLobbyButton.addEventListener('click', showLobby, true);
 messageForm.addEventListener('submit', sendMessage, true);
 privateMessageForm.addEventListener('submit', sendPrivateMessage, true);
+
+navButtons.forEach(function(button) {
+    button.addEventListener('click', function() {
+        showSection(button.dataset.target);
+    });
+});


### PR DESCRIPTION
## Summary
- reorganized the HTML into a mobile app shell with header and bottom tab bar for lobby, chat, and settings views
- refreshed CSS with full-height mobile layout, fixed header/footer, and card-style sections with scrollable content areas
- wired navigation buttons in JavaScript to toggle app sections and update the header title

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936ea38e754832f9d9076866a0bfe67)