### PR TITLE
Add lobby search input for connected users

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -455,6 +455,27 @@ button.accent {
     background: #c1c1c1;
 }
 
+#lobby-page .search-wrapper {
+    width: 100%;
+}
+
+.search-input {
+    width: 100%;
+    padding: 10px 14px;
+    border: 1px solid #d6d9de;
+    border-radius: 12px;
+    font-size: 15px;
+    outline: none;
+    background: #f8fafc;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-input:focus {
+    border-color: #128ff2;
+    box-shadow: 0 0 0 3px rgba(18, 143, 242, 0.15);
+    background: #ffffff;
+}
+
 #lobby-page #connectedUsers .user-name {
     flex: 1;
     font-weight: 600;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -39,6 +39,9 @@
                     <div class="card">
                         <div class="card-header">
                             <h2>Usuarios conectados</h2>
+                            <div class="search-wrapper">
+                                <input type="text" id="connectedUsersSearch" class="search-input" placeholder="Buscar usuario" aria-label="Buscar usuario" autocomplete="off">
+                            </div>
                         </div>
                         <ul id="connectedUsers" class="card-list"></ul>
                         <button id="forumButton" type="button" class="primary lobby-button">Entrar al foro</button>

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -15,6 +15,7 @@ var messageArea = document.querySelector('#messageArea');
 var connectingElement = document.querySelector('.connecting');
 var connectionStatusBanner = document.querySelector('#connectionStatus');
 var connectedUsers = document.querySelector('#connectedUsers');
+var connectedUsersSearch = document.querySelector('#connectedUsersSearch');
 var openChats = document.querySelector('#openChats');
 var privateChatPanel = document.querySelector('#private-chat-panel');
 var privateMessageArea = document.querySelector('#privateMessageArea');
@@ -30,6 +31,7 @@ var stompClient = null;
 var username = null;
 var publicChatSubscription = null;
 var knownUsers = [];
+var latestUsers = [];
 
 var conversations = {};
 var activeConversationId = null;
@@ -256,64 +258,78 @@ function resetPrivateChats() {
 
 function onUsersReceived(payload) {
     var users = JSON.parse(payload.body);
-    knownUsers = (users || []).map(function(user) { return user.username; });
+    latestUsers = users || [];
+    knownUsers = latestUsers.map(function(user) { return user.username; });
+    renderConnectedUsers();
+}
+
+function renderConnectedUsers() {
+    if (!connectedUsers) {
+        return;
+    }
+
+    var searchTerm = connectedUsersSearch ? connectedUsersSearch.value.trim().toLowerCase() : '';
     connectedUsers.innerHTML = '';
 
-    if (!users || users.length === 0) {
-        var li = document.createElement('li');
-        li.textContent = 'No hay usuarios conectados';
-        connectedUsers.appendChild(li);
-    } else {
-        users
-            .slice()
-            .sort(function(a, b) {
-                if (a.online === b.online) {
-                    return a.username.localeCompare(b.username);
-                }
-                return a.online ? -1 : 1;
-            })
-            .forEach(function(user) {
-                var li = document.createElement('li');
-                li.classList.add('user-row');
-                li.dataset.username = user.username;
+    var sortedUsers = latestUsers.slice().sort(function(a, b) {
+        if (a.online === b.online) {
+            return a.username.localeCompare(b.username);
+        }
+        return a.online ? -1 : 1;
+    });
 
-                var statusIndicator = document.createElement('span');
-                statusIndicator.classList.add('user-status');
-                statusIndicator.classList.add(user.online ? 'online' : 'offline');
-                statusIndicator.title = user.online ? 'En línea' : 'Desconectado';
+    var filteredUsers = sortedUsers.filter(function(user) {
+        return !searchTerm || user.username.toLowerCase().indexOf(searchTerm) !== -1;
+    });
 
-                var nameElement = document.createElement('span');
-                nameElement.classList.add('user-name');
-                nameElement.textContent = user.username;
-
-                var stateLabel = document.createElement('span');
-                stateLabel.classList.add('user-state-label');
-                stateLabel.classList.add(user.online ? 'online' : 'offline');
-                stateLabel.textContent = user.online ? 'En línea' : 'Desconectado';
-
-                var unread = getUnreadCountForUser(user.username);
-                var unreadBadge = null;
-                if (unread > 0) {
-                    unreadBadge = document.createElement('span');
-                    unreadBadge.classList.add('unread-badge');
-                    unreadBadge.textContent = unread;
-                }
-
-                if (user.online && user.username !== username) {
-                    li.addEventListener('click', function() {
-                        startPrivateConversation(user.username);
-                    });
-                }
-
-                li.appendChild(statusIndicator);
-                li.appendChild(nameElement);
-                li.appendChild(stateLabel);
-                if (unreadBadge) {
-                    li.appendChild(unreadBadge);
-                }
-                connectedUsers.appendChild(li);
-            });
+    if (filteredUsers.length === 0) {
+        var emptyLi = document.createElement('li');
+        emptyLi.textContent = searchTerm ? 'No hay usuarios que coincidan' : 'No hay usuarios conectados';
+        connectedUsers.appendChild(emptyLi);
+        return;
     }
+
+    filteredUsers.forEach(function(user) {
+        var li = document.createElement('li');
+        li.classList.add('user-row');
+        li.dataset.username = user.username;
+
+        var statusIndicator = document.createElement('span');
+        statusIndicator.classList.add('user-status');
+        statusIndicator.classList.add(user.online ? 'online' : 'offline');
+        statusIndicator.title = user.online ? 'En línea' : 'Desconectado';
+
+        var nameElement = document.createElement('span');
+        nameElement.classList.add('user-name');
+        nameElement.textContent = user.username;
+
+        var stateLabel = document.createElement('span');
+        stateLabel.classList.add('user-state-label');
+        stateLabel.classList.add(user.online ? 'online' : 'offline');
+        stateLabel.textContent = user.online ? 'En línea' : 'Desconectado';
+
+        var unread = getUnreadCountForUser(user.username);
+        var unreadBadge = null;
+        if (unread > 0) {
+            unreadBadge = document.createElement('span');
+            unreadBadge.classList.add('unread-badge');
+            unreadBadge.textContent = unread;
+        }
+
+        if (user.online && user.username !== username) {
+            li.addEventListener('click', function() {
+                startPrivateConversation(user.username);
+            });
+        }
+
+        li.appendChild(statusIndicator);
+        li.appendChild(nameElement);
+        li.appendChild(stateLabel);
+        if (unreadBadge) {
+            li.appendChild(unreadBadge);
+        }
+        connectedUsers.appendChild(li);
+    });
 }
 
 function onError(error) {
@@ -660,3 +676,7 @@ navButtons.forEach(function(button) {
         showSection(button.dataset.target);
     });
 });
+
+if (connectedUsersSearch) {
+    connectedUsersSearch.addEventListener('input', renderConnectedUsers);
+}


### PR DESCRIPTION
## Summary
- add a search field under the lobby header to filter connected users by name
- filter the connected users list in the client while keeping status indicators and unread badges
- style the search input for a mobile-friendly appearance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936eb2f66c8832f9530ec44a3180be5)