### PR TITLE
Reorganize lobby and chat navigation

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -44,48 +44,35 @@
                             </div>
                         </div>
                         <ul id="connectedUsers" class="card-list"></ul>
-                        <button id="forumButton" type="button" class="primary lobby-button">Entrar al foro</button>
-                    </div>
-                    <div class="card">
-                        <div class="card-header">
-                            <h2>Chats privados</h2>
-                            <p class="private-helper">Selecciona un usuario o un chat abierto para conversar.</p>
-                        </div>
-                        <ul id="openChats" class="card-list"></ul>
-                        <div id="private-chat-panel" class="hidden">
-                            <div class="chat-header">
-                                <h3 id="privateChatHeading">Conversación privada</h3>
-                            </div>
-                            <div id="privateMessageArea" class="private-messages"></div>
-                            <form id="privateMessageForm" name="privateMessageForm">
-                                <div class="form-group">
-                                    <div class="input-group clearfix">
-                                        <input type="text" id="privateMessage" placeholder="Escribe un mensaje..." autocomplete="off" class="form-control"/>
-                                        <button type="submit" class="primary">Enviar</button>
-                                    </div>
-                                </div>
-                            </form>
-                        </div>
-                        <div id="noPrivateChat" class="private-empty">
-                            <p>No hay conversaciones abiertas.</p>
-                        </div>
+                        <button id="forumButton" type="button" class="primary lobby-button">Ir a chats</button>
                     </div>
                 </div>
             </section>
 
             <section id="chat-page" class="app-section hidden">
                 <div class="section-scroll">
-                    <div class="card chat-card">
-                        <div class="chat-header">
-                            <h2>Chat Demo</h2>
+                    <div id="chat-list-card" class="card">
+                        <div class="card-header">
+                            <h2>Chats abiertos</h2>
+                            <p class="private-helper">Selecciona un chat para continuar la conversación.</p>
                         </div>
-                        <div class="connecting">Connecting...</div>
-                        <ul id="messageArea"></ul>
-                        <form id="messageForm" name="messageForm" nameForm="messageForm">
+                        <ul id="openChats" class="card-list"></ul>
+                        <div id="noPrivateChat" class="private-empty">
+                            <p>No hay conversaciones abiertas todavía.</p>
+                        </div>
+                    </div>
+
+                    <div id="chat-conversation-card" class="card hidden">
+                        <div class="chat-header">
+                            <button id="backToChatList" type="button" class="icon-button" aria-label="Volver a la lista">&#8592;</button>
+                            <h3 id="privateChatHeading">Conversación privada</h3>
+                        </div>
+                        <div id="privateMessageArea" class="private-messages"></div>
+                        <form id="privateMessageForm" name="privateMessageForm">
                             <div class="form-group">
                                 <div class="input-group clearfix">
-                                    <input type="text" id="message" placeholder="Type a message..." autocomplete="off" class="form-control"/>
-                                    <button type="submit" class="primary">Send</button>
+                                    <input type="text" id="privateMessage" placeholder="Escribe un mensaje..." autocomplete="off" class="form-control"/>
+                                    <button type="submit" class="primary">Enviar</button>
                                 </div>
                             </div>
                         </form>

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -17,13 +17,15 @@ var connectionStatusBanner = document.querySelector('#connectionStatus');
 var connectedUsers = document.querySelector('#connectedUsers');
 var connectedUsersSearch = document.querySelector('#connectedUsersSearch');
 var openChats = document.querySelector('#openChats');
-var privateChatPanel = document.querySelector('#private-chat-panel');
+var chatListCard = document.querySelector('#chat-list-card');
+var chatConversationCard = document.querySelector('#chat-conversation-card');
 var privateMessageArea = document.querySelector('#privateMessageArea');
 var privateMessageForm = document.querySelector('#privateMessageForm');
 var privateMessageInput = document.querySelector('#privateMessage');
 var privateChatHeading = document.querySelector('#privateChatHeading');
 var noPrivateChat = document.querySelector('#noPrivateChat');
 var navButtons = document.querySelectorAll('.nav-item[data-target]');
+var backToChatListButton = document.querySelector('#backToChatList');
 
 var STORAGE_KEY = 'chat-state';
 
@@ -110,7 +112,7 @@ function updateTitle(sectionId) {
     }
     var titles = {
         'lobby-page': 'Usuarios',
-        'chat-page': 'Chat Demo',
+        'chat-page': 'Chats',
         'settings-page': 'Ajustes'
     };
 
@@ -136,6 +138,24 @@ function showSection(sectionId) {
     });
 
     updateTitle(sectionId);
+}
+
+function showChatListView() {
+    if (chatListCard) {
+        chatListCard.classList.remove('hidden');
+    }
+    if (chatConversationCard) {
+        chatConversationCard.classList.add('hidden');
+    }
+}
+
+function showChatConversationView() {
+    if (chatListCard) {
+        chatListCard.classList.add('hidden');
+    }
+    if (chatConversationCard) {
+        chatConversationCard.classList.remove('hidden');
+    }
 }
 
 function restoreStateAfterLogin() {
@@ -243,8 +263,18 @@ function showLobby(event) {
         publicChatSubscription.unsubscribe();
         publicChatSubscription = null;
     }
-    messageArea.innerHTML = '';
+    if (messageArea) {
+        messageArea.innerHTML = '';
+    }
     event.preventDefault();
+}
+
+function goToChatList(event) {
+    showSection('chat-page');
+    showChatListView();
+    if (event) {
+        event.preventDefault();
+    }
 }
 
 function resetPrivateChats() {
@@ -252,7 +282,7 @@ function resetPrivateChats() {
     activeConversationId = null;
     openChats.innerHTML = '';
     privateMessageArea.innerHTML = '';
-    privateChatPanel.classList.add('hidden');
+    showChatListView();
     noPrivateChat.classList.remove('hidden');
 }
 
@@ -366,6 +396,8 @@ function startPrivateConversation(targetUser) {
     ensureConversation(conversationId, targetUser);
 
     subscribeToConversation(conversationId, targetUser);
+    showSection('chat-page');
+    showChatConversationView();
     setActiveConversation(conversationId);
     renderOpenChats();
     persistState();
@@ -396,7 +428,7 @@ function setActiveConversation(conversationId) {
 
     markConversationAsRead(conversationId);
 
-    privateChatPanel.classList.remove('hidden');
+    showChatConversationView();
     noPrivateChat.classList.add('hidden');
     privateChatHeading.textContent = 'Chat con ' + conversation.target;
     renderConversationMessages(conversationId);
@@ -416,6 +448,7 @@ function renderOpenChats() {
             button.classList.add('active-chat');
         }
         button.addEventListener('click', function() {
+            showChatConversationView();
             setActiveConversation(id);
         });
         li.appendChild(button);
@@ -437,7 +470,9 @@ function renderOpenChats() {
 
     if (Object.keys(conversations).length === 0) {
         noPrivateChat.classList.remove('hidden');
-        privateChatPanel.classList.add('hidden');
+        showChatListView();
+    } else {
+        noPrivateChat.classList.add('hidden');
     }
 }
 
@@ -666,17 +701,32 @@ function getUnreadCountForUser(user) {
 }
 
 usernameForm.addEventListener('submit', login, true);
-forumButton.addEventListener('click', connect, true);
+if (forumButton) {
+    forumButton.addEventListener('click', goToChatList, true);
+}
 backToLoginButton.addEventListener('click', showLogin, true);
-messageForm.addEventListener('submit', sendMessage, true);
-privateMessageForm.addEventListener('submit', sendPrivateMessage, true);
+if (messageForm) {
+    messageForm.addEventListener('submit', sendMessage, true);
+}
+if (privateMessageForm) {
+    privateMessageForm.addEventListener('submit', sendPrivateMessage, true);
+}
 
 navButtons.forEach(function(button) {
     button.addEventListener('click', function() {
         showSection(button.dataset.target);
+        if (button.dataset.target === 'chat-page') {
+            showChatListView();
+        }
     });
 });
 
 if (connectedUsersSearch) {
     connectedUsersSearch.addEventListener('input', renderConnectedUsers);
+}
+
+if (backToChatListButton) {
+    backToChatListButton.addEventListener('click', function() {
+        showChatListView();
+    });
 }


### PR DESCRIPTION
## Summary
- move open chats and private conversation UI into the chat section with dedicated list and conversation views
- allow selecting a user in the lobby to jump into their private chat and return to the open chats list via a back control
- harden event bindings around the removed public chat form elements and update section titles

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936efc54af8832f8a11380fc02a6f71)