### PR TITLE
Improve private chat layout and metadata

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -254,6 +254,12 @@ button.accent {
     height: 100%;
 }
 
+#chat-page .section-scroll {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
 #chat-page ul {
     list-style-type: none;
     background-color: #FFF;
@@ -572,16 +578,29 @@ button.accent {
     flex: 1;
 }
 
+#chat-conversation-card {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
 .private-messages {
-    padding: 10px 20px;
+    padding: 12px 14px 10px;
     overflow-y: auto;
-    height: 220px;
+    flex: 1;
+    min-height: 0;
     border-top: 1px solid #ececec;
     border-bottom: 1px solid #ececec;
+    scroll-behavior: smooth;
+    background: linear-gradient(180deg, #f9fbff 0%, #fff 40%);
 }
 
 .private-messages .message-row {
-    margin-bottom: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 12px;
 }
 
 .private-messages .message-row .sender {
@@ -592,6 +611,57 @@ button.accent {
 .private-messages .message-row.system-row {
     color: #ff4743;
     font-weight: 600;
+}
+
+.private-messages .message-row .message-bubble {
+    max-width: 86%;
+    padding: 10px 12px;
+    border-radius: 14px;
+    position: relative;
+    word-break: break-word;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
+}
+
+.private-messages .message-row.outgoing {
+    align-items: flex-end;
+}
+
+.private-messages .message-row.outgoing .message-bubble {
+    background: #128ff2;
+    color: #fff;
+    border-bottom-right-radius: 6px;
+}
+
+.private-messages .message-row.incoming {
+    align-items: flex-start;
+}
+
+.private-messages .message-row.incoming .message-bubble {
+    background: #eef2ff;
+    color: #1f2933;
+    border-bottom-left-radius: 6px;
+}
+
+.private-messages .message-row .message-meta {
+    font-size: 12px;
+    color: #6b7280;
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
+.private-messages .message-row.outgoing .message-meta {
+    color: #e5e7eb;
+}
+
+.private-messages .message-row .message-text {
+    margin: 0;
+    font-size: 15px;
+    white-space: pre-wrap;
+}
+
+.private-messages .message-row .timestamp {
+    opacity: 0.85;
 }
 
 .private-empty {
@@ -621,4 +691,6 @@ button.accent {
 
 #privateMessageForm {
     padding: 10px 20px 20px 20px;
+    margin-top: auto;
+    background: #fff;
 }

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -487,14 +487,33 @@ function renderConversationMessages(conversationId) {
         var row = document.createElement('div');
         row.classList.add('message-row');
 
+        var isOwnMessage = msg.sender === username;
+        row.classList.add(isOwnMessage ? 'outgoing' : 'incoming');
+
+        var bubble = document.createElement('div');
+        bubble.classList.add('message-bubble');
+
+        var text = document.createElement('p');
+        text.classList.add('message-text');
+        text.textContent = msg.content;
+        bubble.appendChild(text);
+
+        var meta = document.createElement('div');
+        meta.classList.add('message-meta');
+
         var senderSpan = document.createElement('span');
         senderSpan.classList.add('sender');
-        senderSpan.textContent = msg.sender + ':';
-        row.appendChild(senderSpan);
+        senderSpan.textContent = isOwnMessage ? 'Tú' : msg.sender;
 
-        var text = document.createElement('span');
-        text.textContent = msg.content;
-        row.appendChild(text);
+        var time = document.createElement('span');
+        time.classList.add('timestamp');
+        time.textContent = formatTimestamp(msg.createdAt || Date.now());
+
+        meta.appendChild(senderSpan);
+        meta.appendChild(time);
+        bubble.appendChild(meta);
+
+        row.appendChild(bubble);
 
         privateMessageArea.appendChild(row);
     });
@@ -662,6 +681,14 @@ function appendMessageIfNew(conversationId, message) {
         return true;
     }
     return false;
+}
+
+function formatTimestamp(timestamp) {
+    var date = new Date(timestamp);
+    if (isNaN(date.getTime())) {
+        return '';
+    }
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
 function markConversationAsRead(conversationId) {


### PR DESCRIPTION
## Summary
- Adjust private chat layout to flex so the message list fills remaining space with smooth scrolling
- Style conversation bubbles with alignment for sent and received messages and timestamp metadata for readability
- Render private messages with sender labels and formatted times based on their `createdAt` values

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936f62ebb28832fbc890b9bbab4e399)