### PR TITLE
Ajustar lista de usuarios y vista de chats

### DIFF
--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -176,11 +176,11 @@ function restoreStateAfterLogin() {
 
     renderOpenChats();
 
-    if (activeConversationId && conversations[activeConversationId]) {
-        setActiveConversation(activeConversationId);
-    }
-
     refreshUserUnreadBadges();
+
+    // Vuelve siempre a la vista de lista después de restaurar el estado
+    // para evitar mostrar de inmediato la última conversación abierta.
+    showChatListView();
 }
 
 function login(event) {
@@ -289,7 +289,9 @@ function resetPrivateChats() {
 function onUsersReceived(payload) {
     var users = JSON.parse(payload.body);
     latestUsers = users || [];
-    knownUsers = latestUsers.map(function(user) { return user.username; });
+    knownUsers = latestUsers
+        .filter(function(user) { return user.username !== username; })
+        .map(function(user) { return user.username; });
     renderConnectedUsers();
 }
 
@@ -309,7 +311,8 @@ function renderConnectedUsers() {
     });
 
     var filteredUsers = sortedUsers.filter(function(user) {
-        return !searchTerm || user.username.toLowerCase().indexOf(searchTerm) !== -1;
+        var matchesSearch = !searchTerm || user.username.toLowerCase().indexOf(searchTerm) !== -1;
+        return matchesSearch && user.username !== username && !userHasConversation(user.username);
     });
 
     if (filteredUsers.length === 0) {
@@ -681,6 +684,13 @@ function appendMessageIfNew(conversationId, message) {
         return true;
     }
     return false;
+}
+
+function userHasConversation(targetUser) {
+    return Object.keys(conversations).some(function(id) {
+        var conversation = conversations[id];
+        return conversation && conversation.target === targetUser;
+    });
 }
 
 function formatTimestamp(timestamp) {


### PR DESCRIPTION
## Summary
- Mostrar siempre la vista de lista al restaurar el estado para evitar abrir conversaciones previas automáticamente
- Excluir al propio usuario y chats ya abiertos de la lista de usuarios disponibles

## Testing
- No tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936f978e1d0832f9a4ca4ab3f9e46d9)