### PR TITLE
Improve chat view layout and user list updates

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -254,6 +254,15 @@ button.accent {
     height: 100%;
 }
 
+#chat-page:not(.conversation-active) #chat-conversation-card {
+    display: none;
+}
+
+#chat-page.conversation-active #chat-list-card,
+#chat-page.conversation-active #noPrivateChat {
+    display: none;
+}
+
 #chat-page .section-scroll {
     display: flex;
     flex-direction: column;

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -140,6 +140,13 @@ function showSection(sectionId) {
     updateTitle(sectionId);
 }
 
+function toggleConversationLayout(isConversationActive) {
+    if (!chatPage) {
+        return;
+    }
+    chatPage.classList.toggle('conversation-active', !!isConversationActive);
+}
+
 function showChatListView() {
     if (chatListCard) {
         chatListCard.classList.remove('hidden');
@@ -147,6 +154,7 @@ function showChatListView() {
     if (chatConversationCard) {
         chatConversationCard.classList.add('hidden');
     }
+    toggleConversationLayout(false);
 }
 
 function showChatConversationView() {
@@ -156,6 +164,7 @@ function showChatConversationView() {
     if (chatConversationCard) {
         chatConversationCard.classList.remove('hidden');
     }
+    toggleConversationLayout(true);
 }
 
 function restoreStateAfterLogin() {
@@ -284,6 +293,7 @@ function resetPrivateChats() {
     privateMessageArea.innerHTML = '';
     showChatListView();
     noPrivateChat.classList.remove('hidden');
+    renderConnectedUsers();
 }
 
 function onUsersReceived(payload) {
@@ -397,6 +407,7 @@ function startPrivateConversation(targetUser) {
     var conversationId = buildConversationId(username, targetUser);
 
     ensureConversation(conversationId, targetUser);
+    renderConnectedUsers();
 
     subscribeToConversation(conversationId, targetUser);
     showSection('chat-page');
@@ -574,12 +585,16 @@ function onPrivateMessageReceived(payload) {
     var conversationId = message.conversationId || buildConversationId(message.sender, message.target);
 
     var targetUser = message.sender === username ? message.target : message.sender;
+    var conversationExisted = Boolean(conversations[conversationId]);
     if (message.type === 'PRIVATE_ERROR') {
         renderSystemPrivateMessage(message);
         return;
     }
 
     ensureConversation(conversationId, targetUser);
+    if (!conversationExisted) {
+        renderConnectedUsers();
+    }
     if (!activeConversationId) {
         activeConversationId = conversationId;
     }


### PR DESCRIPTION
## Summary
- toggle chat page layout so only the chat list or the active conversation is visible at a time
- hide the conversation card when browsing open chats and show it when opening a conversation
- refresh the connected users list immediately when starting or receiving a private conversation to remove participants from the lobby list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fb917f68832f9055a965b6b57e52)